### PR TITLE
Adding volume type parameter to work for cloudstack 4.16

### DIFF
--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -306,6 +306,7 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 func (c *client) listVMInstanceVolumeIDs(instanceID string) ([]string, error) {
 	p := c.cs.Volume.NewListVolumesParams()
 	p.SetVirtualmachineid(instanceID)
+	p.SetType("DATADISK")
 
 	listVOLResp, err := c.csAsync.Volume.ListVolumes(p)
 	if err != nil {

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -274,7 +274,7 @@ func (c *client) GetOrCreateVMInstance(
 func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 	// Attempt deletion regardless of machine state.
 	p := c.csAsync.VirtualMachine.NewDestroyVirtualMachineParams(*csMachine.Spec.InstanceID)
-	volIDs, err := c.listVMInstanceVolumeIDs(*csMachine.Spec.InstanceID)
+	volIDs, err := c.listVMInstanceDatadiskVolumeIDs(*csMachine.Spec.InstanceID)
 	if err != nil {
 		return err
 	}
@@ -303,9 +303,10 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 	return errors.New("VM deletion in progress")
 }
 
-func (c *client) listVMInstanceVolumeIDs(instanceID string) ([]string, error) {
+func (c *client) listVMInstanceDatadiskVolumeIDs(instanceID string) ([]string, error) {
 	p := c.cs.Volume.NewListVolumesParams()
 	p.SetVirtualmachineid(instanceID)
+	// VM root volumes are destroyed automatically, no need to explicitly include
 	p.SetType("DATADISK")
 
 	listVOLResp, err := c.csAsync.Volume.ListVolumes(p)

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -439,6 +439,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy and finds VM doesn't exist, then returns nil", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, fmt.Errorf("unable to find uuid for id"))
@@ -450,6 +451,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy and returns unexpected error", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, fmt.Errorf("new error"))
@@ -460,6 +462,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error but cannot resolve VM after", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
@@ -473,6 +476,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error and identifies it as expunging", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
@@ -488,6 +492,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error and identifies it as expunged", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
@@ -503,6 +508,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error and identifies it as stopping", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without this change, when I tested CAPC deletion against a 4.16 environment, I was observing the async VM deletion request hang, and log error 

```
(logid:224d9b4e) Complete async job-26801, jobStatus: FAILED, resultCode: 530, result: org.apache.cloudstack.api.response.ExceptionResponse/null/{"uuidList":[],"errorcode":"431","errortext":"The following supplied volumes are not DATADISK attached to the VM: Vol[3269|vm=3266|ROOT]; "}
```

I discussed with some colleagues and they suggested making this change. Root volumes are deleted automatically so they should not be included in the request to destroy the VM, only datadisk

*Testing performed:*
Unit tests pass locally (except user_credentials integ tests). Successfully created and deleted a cloudstack cluster with eks-a in ACS 4.16 and 4.14 using this commit

e2e PR blocking test passed
```
• [SLOW TEST:497.914 seconds]
When testing app deployment to the workload cluster [TC1][PR-Blocking]
/Users/dribinm/workspaces/eksa/cluster-api-provider-cloudstack/test/e2e/deploy_app_test.go:27
  Should be able to download an HTML from the app deployed to the workload cluster
  /Users/dribinm/workspaces/eksa/cluster-api-provider-cloudstack/test/e2e/deploy_app.go:70
------------------------------
SSSSSSSSSSSSSSSSSSSSTEP: Dumping logs from the bootstrap cluster
Failed to get logs for the bootstrap cluster node capi-test-control-plane: exit status 1
STEP: Tearing down the management cluster

JUnit report was created: /Users/dribinm/workspaces/eksa/cluster-api-provider-cloudstack/_artifacts/junit.e2e_suite.1.xml

Ran 1 of 23 Specs in 628.582 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 22 Skipped
PASS
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->